### PR TITLE
voting: Use core/crypto/cert instead of jose

### DIFF
--- a/voting/client/client.go
+++ b/voting/client/client.go
@@ -314,7 +314,7 @@ func (c *client) Get(ctx context.Context, epoch uint64) (*pki.Document, []byte, 
 
 	sigMap, err := s11n.VerifyPeerMulti(r.Payload, c.cfg.Authorities)
 	if err != nil {
-		c.log.Errorf("fufu voting/client: Get() invalid consensus document: %s", err)
+		c.log.Errorf("fufu123 voting/client: Get() invalid consensus document: %s", err)
 		return nil, nil, fmt.Errorf("fufu voting/client: Get() invalid consensus document: %s", err)
 	}
 	if len(sigMap) == len(c.cfg.Authorities) {
@@ -325,7 +325,7 @@ func (c *client) Get(ctx context.Context, epoch uint64) (*pki.Document, []byte, 
 	}
 	id := new(eddsa.PublicKey)
 	for idRaw := range sigMap {
-		id.FromBytes(idRaw[:])
+		id.FromBytes([]byte(idRaw))
 		doc, _, err = s11n.VerifyAndParseDocument(r.Payload, id)
 		if err != nil {
 			return nil, nil, fmt.Errorf("voting/client: Get() impossible signature verification failure: %s", err)

--- a/voting/internal/s11n/descriptor.go
+++ b/voting/internal/s11n/descriptor.go
@@ -1,5 +1,5 @@
 // descriptor.go - Katzenpost Non-voting authority descriptor s11n.
-// Copyright (C) 2017  Yawning Angel.
+// Copyright (C) 2017, 2018  Yawning Angel, masala, David Stainton
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -19,21 +19,22 @@
 package s11n
 
 import (
-	"bytes"
-	"encoding/base64"
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
-	"github.com/katzenpost/core/crypto/eddsa"
+	"github.com/katzenpost/core/crypto/cert"
 	"github.com/katzenpost/core/pki"
 	"github.com/katzenpost/core/sphinx/constants"
 	"github.com/ugorji/go/codec"
 	"golang.org/x/net/idna"
-	"gopkg.in/square/go-jose.v2"
 )
 
-const nodeDescriptorVersion = "voting-v0"
+const (
+	nodeDescriptorVersion = "nonvoting-v0"
+	CertificateExpiration = time.Hour * 1
+)
 
 type nodeDescriptor struct {
 	// Version uniquely identifies the descriptor format as being for the
@@ -44,20 +45,9 @@ type nodeDescriptor struct {
 	pki.MixDescriptor
 }
 
-// SerializeDescriptor serializes a MixDescriptor, and returns a byteslice or error.
-func SerializeDescriptor(base *pki.MixDescriptor) ([]byte, error) {
-	// Serialize the descriptor.
-	var payload []byte
-	enc := codec.NewEncoderBytes(&payload, jsonHandle)
-	if err := enc.Encode(base); err != nil {
-		return nil, err
-	}
-	return payload, nil
-}
-
 // SignDescriptor signs and serializes the descriptor with the provided signing
 // key.
-func SignDescriptor(signingKey *eddsa.PrivateKey, base *pki.MixDescriptor) (string, error) {
+func SignDescriptor(signer cert.Signer, base *pki.MixDescriptor) ([]byte, error) {
 	d := new(nodeDescriptor)
 	d.MixDescriptor = *base
 	d.Version = nodeDescriptorVersion
@@ -66,67 +56,47 @@ func SignDescriptor(signingKey *eddsa.PrivateKey, base *pki.MixDescriptor) (stri
 	var payload []byte
 	enc := codec.NewEncoderBytes(&payload, jsonHandle)
 	if err := enc.Encode(d); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Sign the descriptor.
-	k := jose.SigningKey{
-		Algorithm: jose.EdDSA,
-		Key:       *signingKey.InternalPtr(),
-	}
-	signer, err := jose.NewSigner(k, nil)
+	expiration := time.Now().Add(CertificateExpiration).Unix()
+	signed, err := cert.Sign(signer, payload, expiration)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	signed, err := signer.Sign(payload)
-	if err != nil {
-		return "", err
-	}
+	return signed, nil
+}
 
-	// Serialize the key, descriptor and signature.
-	return signed.CompactSerialize()
+// GetVerifierFromDescriptor returns a verifier for the given
+// mix descriptor certificate.
+func GetVerifierFromDescriptor(rawDesc []byte) (cert.Verifier, error) {
+	payload, err := cert.GetCertified(rawDesc)
+	if err != nil {
+		return nil, err
+	}
+	// Parse the payload.
+	d := new(nodeDescriptor)
+	dec := codec.NewDecoderBytes(payload, jsonHandle)
+	if err = dec.Decode(d); err != nil {
+		return nil, err
+	}
+	return d.IdentityKey, nil
 }
 
 // VerifyAndParseDescriptor verifies the signature and deserializes the
 // descriptor.  MixDescriptors returned from this routine are guaranteed
 // to have been correctly self signed by the IdentityKey listed in the
 // MixDescriptor.
-func VerifyAndParseDescriptor(b []byte, epoch uint64) (*pki.MixDescriptor, error) {
-	signed, err := jose.ParseSigned(string(b))
-	if err != nil {
-		return nil, err
+func VerifyAndParseDescriptor(verifier cert.Verifier, b []byte, epoch uint64) (*pki.MixDescriptor, error) {
+	signatures, err := cert.GetSignatures(b)
+	if len(signatures) != 1 {
+		return nil, fmt.Errorf("nonvoting: Expected 1 signature, got: %v", len(signatures))
 	}
 
-	// So the descriptor is going to be signed by the node's key, which may
-	// be new to the authority (which is doing the decoding).   In an ideal
-	// world this is where embedding the public key in the header solves this
-	// problem, but the library doesn't support doing so for EdDSA signatures.
-	//
-	// Since the descriptors themselves include (perhaps redundantly) a copy
-	// of the IdentityKey used to sign the descriptor, we can reach into
-	// the unverified payload to pull it out instead.
-	//
-	// This is wasteful on the CPU side since it's de-serializing the payload
-	// twice, but this isn't a critical path operation, nor is the non-voting
-	// authority something that will do this a lot.
-	if len(signed.Signatures) != 1 {
-		return nil, fmt.Errorf("voting: Expected 1 signature, got: %v", len(signed.Signatures))
-	}
-	alg := signed.Signatures[0].Header.Algorithm
-	if alg != "EdDSA" {
-		return nil, fmt.Errorf("voting: Unsupported signature algorithm: '%v'", alg)
-	}
-	candidatePk, err := extractSignedDescriptorPublicKey(b)
+	// Verify that the descriptor is signed by the verifier.
+	payload, err := cert.Verify(verifier, b)
 	if err != nil {
-		return nil, err
-	}
-
-	// Verify that the descriptor is signed by the key in the header.
-	payload, err := signed.Verify(*candidatePk.InternalPtr())
-	if err != nil {
-		if err == jose.ErrCryptoFailure {
-			err = fmt.Errorf("voting: Invalid descriptor signature")
-		}
 		return nil, err
 	}
 
@@ -139,57 +109,12 @@ func VerifyAndParseDescriptor(b []byte, epoch uint64) (*pki.MixDescriptor, error
 
 	// Ensure the descriptor is well formed.
 	if d.Version != nodeDescriptorVersion {
-		return nil, fmt.Errorf("voting: Invalid Descriptor Version: '%v'", d.Version)
+		return nil, fmt.Errorf("nonvoting: Invalid Descriptor Version: '%v'", d.Version)
 	}
 	if err = IsDescriptorWellFormed(&d.MixDescriptor, epoch); err != nil {
 		return nil, err
 	}
-
-	// And as the final check, ensure that the key embedded in the descriptor
-	// matches the key we teased out of the payload, that we used to validate
-	// the signature.
-	if !candidatePk.Equal(d.IdentityKey) {
-		return nil, fmt.Errorf("voting: Descriptor signing key mismatch")
-	}
 	return &d.MixDescriptor, nil
-}
-
-func extractSignedDescriptorPublicKey(b []byte) (*eddsa.PublicKey, error) {
-	// Per RFC 7515:
-	//
-	// In the JWS Compact Serialization, a JWS is represented as the
-	// concatenation:
-	//
-	//   BASE64URL(UTF8(JWS Protected Header)) || '.' ||
-	//   BASE64URL(JWS Payload) || '.' ||
-	//   BASE64URL(JWS Signature)
-	//
-	// The JOSE library used doesn't support embedding EdDSA JWK Public Keys
-	// so this reaches into the (unverified) payload, to pull out the
-	// descriptor's PublicKey.
-	//
-	// XXX: Doing things this way, decodes the same object twice, once
-	// prior to validating the signature, and once after, which is
-	// inefficient, but this shouldn't be a critical path operation.
-
-	spl := bytes.Split(b, []byte{'.'})
-	if len(spl) != 3 {
-		return nil, fmt.Errorf("voting: Splitting at '.' returned unexpected number of sections: %v", len(spl))
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(string(spl[1]))
-	if err != nil {
-		return nil, fmt.Errorf("voting: (Early) Failed to decode: %v", err)
-	}
-	d := new(nodeDescriptor)
-	dec := codec.NewDecoderBytes(payload, jsonHandle)
-	if err = dec.Decode(d); err != nil {
-		return nil, fmt.Errorf("voting: (Early) Failed to deserialize: %v", err)
-	}
-	candidatePk := d.IdentityKey
-	if candidatePk == nil {
-		return nil, fmt.Errorf("voting: (Early) Descriptor missing IdentityKey")
-	}
-	return candidatePk, nil
 }
 
 // IsDescriptorWellFormed validates the descriptor and returns a descriptive
@@ -197,38 +122,38 @@ func extractSignedDescriptorPublicKey(b []byte) (*eddsa.PublicKey, error) {
 // a PKI Document.
 func IsDescriptorWellFormed(d *pki.MixDescriptor, epoch uint64) error {
 	if d.Name == "" {
-		return fmt.Errorf("voting: Descriptor missing Name")
+		return fmt.Errorf("nonvoting: Descriptor missing Name")
 	}
 	if len(d.Name) > constants.NodeIDLength {
-		return fmt.Errorf("voting: Descriptor Name '%v' exceeds max length", d.Name)
+		return fmt.Errorf("nonvoting: Descriptor Name '%v' exceeds max length", d.Name)
 	}
 	if d.LinkKey == nil {
-		return fmt.Errorf("voting: Descriptor missing LinkKey")
+		return fmt.Errorf("nonvoting: Descriptor missing LinkKey")
 	}
 	if d.IdentityKey == nil {
-		return fmt.Errorf("voting: Descriptor missing IdentityKey")
+		return fmt.Errorf("nonvoting: Descriptor missing IdentityKey")
 	}
 	if d.MixKeys[epoch] == nil {
-		return fmt.Errorf("voting: Descriptor missing MixKey[%v]", epoch)
+		return fmt.Errorf("nonvoting: Descriptor missing MixKey[%v]", epoch)
 	}
 	for e := range d.MixKeys {
 		// TODO: Should this check that the epochs in MixKey are sequential?
 		if e < epoch || e >= epoch+3 {
-			return fmt.Errorf("voting: Descriptor contains MixKey for invalid epoch: %v", d)
+			return fmt.Errorf("nonvoting: Descriptor contains MixKey for invalid epoch: %v", d)
 		}
 	}
 	if len(d.Addresses) == 0 {
-		return fmt.Errorf("voting: Descriptor missing Addresses")
+		return fmt.Errorf("nonvoting: Descriptor missing Addresses")
 	}
 	for transport, addrs := range d.Addresses {
 		if len(addrs) == 0 {
-			return fmt.Errorf("voting: Descriptor contains empty Address list for transport '%v'", transport)
+			return fmt.Errorf("nonvoting: Descriptor contains empty Address list for transport '%v'", transport)
 		}
 
 		var expectedIPVer int
 		switch transport {
 		case pki.TransportInvalid:
-			return fmt.Errorf("voting: Descriptor contains invalid Transport")
+			return fmt.Errorf("nonvoting: Descriptor contains invalid Transport")
 		case pki.TransportTCPv4:
 			expectedIPVer = 4
 		case pki.TransportTCPv6:
@@ -237,7 +162,7 @@ func IsDescriptorWellFormed(d *pki.MixDescriptor, epoch uint64) error {
 			// Unknown transports are only supported between the client and
 			// provider.
 			if d.Layer != pki.LayerProvider {
-				return fmt.Errorf("voting: Non-provider published Transport '%v'", transport)
+				return fmt.Errorf("nonvoting: Non-provider published Transport '%v'", transport)
 			}
 			if transport != pki.TransportTCP {
 				// Ignore transports that don't have validation logic.
@@ -249,47 +174,47 @@ func IsDescriptorWellFormed(d *pki.MixDescriptor, epoch uint64) error {
 		for _, v := range addrs {
 			h, p, err := net.SplitHostPort(v)
 			if err != nil {
-				return fmt.Errorf("voting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
+				return fmt.Errorf("nonvoting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
 			}
 			if len(h) == 0 {
-				return fmt.Errorf("voting: Descriptor contains invalid address ['%v']'%v'", transport, v)
+				return fmt.Errorf("nonvoting: Descriptor contains invalid address ['%v']'%v'", transport, v)
 			}
 			if port, err := strconv.ParseUint(p, 10, 16); err != nil {
-				return fmt.Errorf("voting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
+				return fmt.Errorf("nonvoting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
 			} else if port == 0 {
-				return fmt.Errorf("voting: Descriptor contains invalid address ['%v']'%v': port is 0", transport, v)
+				return fmt.Errorf("nonvoting: Descriptor contains invalid address ['%v']'%v': port is 0", transport, v)
 			}
 			switch expectedIPVer {
 			case 4, 6:
 				if ver, err := getIPVer(h); err != nil {
-					return fmt.Errorf("voting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
+					return fmt.Errorf("nonvoting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
 				} else if ver != expectedIPVer {
-					return fmt.Errorf("voting: Descriptor contains invalid address ['%v']'%v': IP version mismatch", transport, v)
+					return fmt.Errorf("nonvoting: Descriptor contains invalid address ['%v']'%v': IP version mismatch", transport, v)
 				}
 			default:
 				// This must be TransportTCP or something else that supports
 				// "sensible" DNS style hostnames.  Validate that they are
 				// at least somewhat well formed.
 				if _, err := idna.Lookup.ToASCII(h); err != nil {
-					return fmt.Errorf("voting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
+					return fmt.Errorf("nonvoting: Descriptor contains invalid address ['%v']'%v': %v", transport, v, err)
 				}
 			}
 		}
 	}
 	if len(d.Addresses[pki.TransportTCPv4]) == 0 {
-		return fmt.Errorf("voting: Descriptor contains no TCPv4 addresses")
+		return fmt.Errorf("nonvoting: Descriptor contains no TCPv4 addresses")
 	}
 	switch d.Layer {
 	case 0:
 		if d.Kaetzchen != nil {
-			return fmt.Errorf("voting: Descriptor contains Kaetzchen when a mix")
+			return fmt.Errorf("nonvoting: Descriptor contains Kaetzchen when a mix")
 		}
 	case pki.LayerProvider:
 		if err := validateKaetzchen(d.Kaetzchen); err != nil {
-			return fmt.Errorf("voting: Descriptor contains invalid Kaetzchen block: %v", err)
+			return fmt.Errorf("nonvoting: Descriptor contains invalid Kaetzchen block: %v", err)
 		}
 	default:
-		return fmt.Errorf("voting: Descriptor self-assigned Layer: '%v'", d.Layer)
+		return fmt.Errorf("nonvoting: Descriptor self-assigned Layer: '%v'", d.Layer)
 	}
 	return nil
 }

--- a/voting/internal/s11n/descriptor_test.go
+++ b/voting/internal/s11n/descriptor_test.go
@@ -73,10 +73,8 @@ func TestDescriptor(t *testing.T) {
 	signed, err := SignDescriptor(identityPriv, d)
 	require.NoError(err, "SignDescriptor()")
 
-	t.Logf("signed descriptor: '%v'", signed)
-
 	// Verify and deserialize the signed descriptor.
-	dd, err := VerifyAndParseDescriptor([]byte(signed), debugTestEpoch)
+	dd, err := VerifyAndParseDescriptor(identityPriv.PublicKey(), signed, debugTestEpoch)
 	require.NoError(err, "VerifyAndParseDescriptor()")
 
 	t.Logf("Deserialized descriptor: '%v'", dd)

--- a/voting/internal/s11n/document.go
+++ b/voting/internal/s11n/document.go
@@ -1,5 +1,5 @@
 // document.go - Katzenpost Non-voting authority document s11n.
-// Copyright (C) 2017  Yawning Angel.
+// Copyright (C) 2017, 2018  Yawning Angel, masala, David Stainton
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,19 +17,20 @@
 package s11n
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/katzenpost/authority/voting/server/config"
-	"github.com/katzenpost/core/crypto/eddsa"
+	"github.com/katzenpost/core/crypto/cert"
 	"github.com/katzenpost/core/pki"
 	"github.com/ugorji/go/codec"
-	"gopkg.in/square/go-jose.v2"
 )
 
 const (
-	documentVersion = "voting-document-v0"
+	DocumentVersion = "voting-document-v0"
 	// SharedRandomLength is the length in bytes of a SharedRandomCommit.
 	SharedRandomLength = 40
 	// SharedRandomValueLength is the length in bytes of a SharedRandomValue.
@@ -68,12 +69,8 @@ type Document struct {
 }
 
 // FromPayload deserializes, then verifies a Document, and returns the Document or error.
-func FromPayload(verificationKey interface{}, payload []byte) (*Document, error) {
-	signed, err := jose.ParseSigned(string(payload))
-	if err != nil {
-		return nil, err
-	}
-	_, _, verified, err := signed.VerifyMulti(verificationKey)
+func FromPayload(verifier cert.Verifier, payload []byte) (*Document, error) {
+	verified, err := cert.Verify(verifier, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -86,137 +83,81 @@ func FromPayload(verificationKey interface{}, payload []byte) (*Document, error)
 }
 
 // SignDocument signs and serializes the document with the provided signing key.
-func SignDocument(signingKey *eddsa.PrivateKey, d *Document) (string, error) {
-	d.Version = documentVersion
+func SignDocument(signer cert.Signer, d *Document) ([]byte, error) {
+	d.Version = DocumentVersion
 
 	// Serialize the document.
 	var payload []byte
 	enc := codec.NewEncoderBytes(&payload, jsonHandle)
 	if err := enc.Encode(d); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Sign the document.
-	k := jose.SigningKey{
-		Algorithm: jose.EdDSA,
-		Key:       *signingKey.InternalPtr(),
-	}
-	signer, err := jose.NewSigner(k, nil)
-	if err != nil {
-		return "", err
-	}
-	signed, err := signer.Sign(payload)
-	if err != nil {
-		return "", err
-	}
-
-	// Serialize the key, descriptor and signature.
-	return signed.CompactSerialize()
-}
-
-// MultiSignTestDocument signs and serializes the document with the provided signing key.
-func MultiSignTestDocument(signingKeys []*eddsa.PrivateKey, d *Document) (string, error) {
-	d.Version = documentVersion
-	// Serialize the document.
-	var payload []byte
-	enc := codec.NewEncoderBytes(&payload, jsonHandle)
-	if err := enc.Encode(d); err != nil {
-		return "", err
-	}
-	keySet := []jose.SigningKey{}
-	for _, key := range signingKeys {
-		k := jose.SigningKey{
-			Algorithm: jose.EdDSA,
-			Key:       *key.InternalPtr(),
-		}
-		keySet = append(keySet, k)
-	}
-	// Sign the document.
-	signer, err := jose.NewMultiSigner(keySet, nil)
-	if err != nil {
-		return "", err
-	}
-	signed, err := signer.Sign(payload)
-	if err != nil {
-		return "", err
-	}
-	// Serialize the key, descriptor and signature.
-	return signed.FullSerialize(), nil
+	expiration := time.Now().Add(CertificateExpiration).Unix()
+	return cert.Sign(signer, payload, expiration)
 }
 
 // MultiSignDocument signs and serializes the document with the provided signing key, adding the signature to the existing signatures.
-func MultiSignDocument(signingKey *eddsa.PrivateKey, peerSignatures map[[eddsa.PublicKeySize]byte]*jose.Signature, d *Document) (string, error) {
-	d.Version = documentVersion
+func MultiSignDocument(signer cert.Signer, peerSignatures []*cert.Signature, verifiers map[string]cert.Verifier, d *Document) ([]byte, error) {
+	d.Version = DocumentVersion
 
 	// Serialize the document.
 	var payload []byte
 	enc := codec.NewEncoderBytes(&payload, jsonHandle)
 	if err := enc.Encode(d); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Sign the document.
-	k := jose.SigningKey{
-		Algorithm: jose.EdDSA,
-		Key:       *signingKey.InternalPtr(),
-	}
-	signer, err := jose.NewMultiSigner([]jose.SigningKey{k}, nil) // XXX multiple signing keys
+	expiration := time.Now().Add(CertificateExpiration).Unix()
+	signed, err := cert.Sign(signer, payload, expiration)
 	if err != nil {
-		return "", err
-	}
-	signed, err := signer.Sign(payload)
-	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// attach peer signatures
-	if peerSignatures != nil {
-		for _, sig := range peerSignatures {
-			signed.Signatures = append(signed.Signatures, *sig)
+	for _, signature := range peerSignatures {
+		n := bytes.Index(signature.Identity, []byte{0})
+		s := string(signature.Identity[:n])
+		verifier := verifiers[s]
+		signed, err = cert.AddSignature(verifier, *signature, signed)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	// Serialize the key, descriptor and signature.
-	return signed.FullSerialize(), nil
+	return signed, nil
 }
 
 // VerifyPeerMulti returns a map of keys to signatures for
 // the peer keys that produced a valid signature
-func VerifyPeerMulti(payload []byte, peers []*config.AuthorityPeer) (map[[eddsa.PublicKeySize]byte]*jose.Signature, error) {
-	signed, err := jose.ParseSigned(string(payload))
+func VerifyPeerMulti(payload []byte, peers []*config.AuthorityPeer) (map[string]*cert.Signature, error) {
+	_, err := cert.Verify(peers[0].IdentityPublicKey, payload)
 	if err != nil {
-		return nil, fmt.Errorf("VerifyPeerMulti failure: %s", err)
+		return nil, err
 	}
-	sigMap := make(map[[eddsa.PublicKeySize]byte]*jose.Signature)
-	for _, peer := range peers {
-		_, signature, _, err := signed.VerifyMulti(*peer.IdentityPublicKey.InternalPtr())
-		if err == nil {
-			sigMap[peer.IdentityPublicKey.ByteArray()] = &signature
+	sigMap := make(map[string]*cert.Signature)
+	for i := 1; i < len(peers); i++ {
+		_, err = cert.Verify(peers[i].IdentityPublicKey, payload)
+		if err != nil {
+			return nil, err
 		}
+	}
+	signatures, err := cert.GetSignatures(payload)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range signatures {
+		sigMap[string(s.Identity)] = &s
 	}
 	return sigMap, nil
 }
 
 // VerifyAndParseDocument verifies the signautre and deserializes the document.
-func VerifyAndParseDocument(b []byte, publicKey *eddsa.PublicKey) (*pki.Document, []byte, error) {
-	signed, err := jose.ParseSigned(string(b))
+func VerifyAndParseDocument(b []byte, verifier cert.Verifier) (*pki.Document, []byte, error) {
+	payload, err := cert.Verify(verifier, b)
 	if err != nil {
-		return nil, nil, fmt.Errorf("authority: jose.ParseSigned failed: %s", err)
-	}
-
-	// XXX shouldn't the library do this for us?
-	for _, sig := range signed.Signatures {
-		alg := sig.Header.Algorithm
-		if alg != "EdDSA" {
-			return nil, nil, fmt.Errorf("authority: Unsupported signature algorithm: '%v'", alg)
-		}
-	}
-
-	_, _, payload, err := signed.VerifyMulti(*publicKey.InternalPtr())
-	if err != nil {
-		if err == jose.ErrCryptoFailure {
-			err = fmt.Errorf("authority: Invalid document signature")
-		}
 		return nil, nil, err
 	}
 
@@ -228,7 +169,7 @@ func VerifyAndParseDocument(b []byte, publicKey *eddsa.PublicKey) (*pki.Document
 	}
 
 	// Ensure the document is well formed.
-	if d.Version != documentVersion {
+	if d.Version != DocumentVersion {
 		return nil, nil, fmt.Errorf("authority: Invalid Document Version: '%v'", d.Version)
 	}
 
@@ -276,7 +217,11 @@ func VerifyAndParseDocument(b []byte, publicKey *eddsa.PublicKey) (*pki.Document
 
 	for layer, nodes := range d.Topology {
 		for _, rawDesc := range nodes {
-			desc, err := VerifyAndParseDescriptor(rawDesc, doc.Epoch)
+			verifier, err := GetVerifierFromDescriptor(rawDesc)
+			if err != nil {
+				return nil, nil, err
+			}
+			desc, err := VerifyAndParseDescriptor(verifier, rawDesc, doc.Epoch)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -285,9 +230,13 @@ func VerifyAndParseDocument(b []byte, publicKey *eddsa.PublicKey) (*pki.Document
 	}
 
 	for _, rawDesc := range d.Providers {
-		desc, err := VerifyAndParseDescriptor(rawDesc, doc.Epoch)
+		verifier, err := GetVerifierFromDescriptor(rawDesc)
 		if err != nil {
-			return nil, nil, fmt.Errorf("VerifyAndParseDocument fail: VerifyAndParseDescriptor failure: %s", err)
+			return nil, nil, err
+		}
+		desc, err := VerifyAndParseDescriptor(verifier, rawDesc, doc.Epoch)
+		if err != nil {
+			return nil, nil, err
 		}
 		doc.Providers = append(doc.Providers, desc)
 	}
@@ -309,38 +258,38 @@ func VerifyAndParseDocument(b []byte, publicKey *eddsa.PublicKey) (*pki.Document
 // IsDocumentWellFormed validates the document and returns a descriptive error
 // iff there are any problems that invalidates the document.
 func IsDocumentWellFormed(d *pki.Document) error {
-	pks := make(map[[eddsa.PublicKeySize]byte]bool)
+	pks := make(map[string]bool)
 	if len(d.Topology) == 0 {
-		return fmt.Errorf("voting: Document contains no Topology")
+		return fmt.Errorf("nonvoting: Document contains no Topology")
 	}
 	for layer, nodes := range d.Topology {
 		if len(nodes) == 0 {
-			return fmt.Errorf("voting: Document Topology layer %d contains no nodes", layer)
+			return fmt.Errorf("nonvoting: Document Topology layer %d contains no nodes", layer)
 		}
 		for _, desc := range nodes {
 			if err := IsDescriptorWellFormed(desc, d.Epoch); err != nil {
 				return err
 			}
-			pk := desc.IdentityKey.ByteArray()
+			pk := string(desc.IdentityKey.Identity())
 			if _, ok := pks[pk]; ok {
-				return fmt.Errorf("voting: Document contains multiple entries for %v", desc.IdentityKey)
+				return fmt.Errorf("nonvoting: Document contains multiple entries for %v", desc.IdentityKey)
 			}
 			pks[pk] = true
 		}
 	}
 	if len(d.Providers) == 0 {
-		return fmt.Errorf("voting: Document contains no Providers")
+		return fmt.Errorf("nonvoting: Document contains no Providers")
 	}
 	for _, desc := range d.Providers {
 		if err := IsDescriptorWellFormed(desc, d.Epoch); err != nil {
 			return err
 		}
 		if desc.Layer != pki.LayerProvider {
-			return fmt.Errorf("voting: Document lists %v as a Provider with layer %v", desc.IdentityKey, desc.Layer)
+			return fmt.Errorf("nonvoting: Document lists %v as a Provider with layer %v", desc.IdentityKey, desc.Layer)
 		}
-		pk := desc.IdentityKey.ByteArray()
+		pk := string(desc.IdentityKey.Identity())
 		if _, ok := pks[pk]; ok {
-			return fmt.Errorf("voting: Document contains multiple entries for %v", desc.IdentityKey)
+			return fmt.Errorf("nonvoting: Document contains multiple entries for %v", desc.IdentityKey)
 		}
 		pks[pk] = true
 	}

--- a/voting/server/state.go
+++ b/voting/server/state.go
@@ -33,6 +33,7 @@ import (
 	bolt "github.com/coreos/bbolt"
 	"github.com/katzenpost/authority/voting/internal/s11n"
 	"github.com/katzenpost/authority/voting/server/config"
+	"github.com/katzenpost/core/crypto/cert"
 	"github.com/katzenpost/core/crypto/eddsa"
 	"github.com/katzenpost/core/crypto/rand"
 	"github.com/katzenpost/core/epochtime"
@@ -43,7 +44,6 @@ import (
 	"github.com/katzenpost/core/worker"
 	"golang.org/x/crypto/sha3"
 	"gopkg.in/op/go-logging.v1"
-	"gopkg.in/square/go-jose.v2"
 )
 
 const (
@@ -77,40 +77,6 @@ type document struct {
 	raw []byte
 }
 
-func (d *document) getSignatures() ([]jose.Signature, error) {
-	if d.raw != nil && d.doc != nil {
-		signed, err := jose.ParseSigned(string(d.raw))
-		if err != nil {
-			return nil, err
-		}
-		return signed.Signatures, nil
-	}
-	return nil, errors.New("document getSignatures failure: struct type not initialized")
-}
-
-func (d *document) addSig(publicKey *eddsa.PublicKey, sig *jose.Signature) error {
-	// caller MUST verify that the signer is authorized
-	// this function only verifies that the signature
-	// is valid and not duplicated.
-	signed, err := jose.ParseSigned(string(d.raw))
-	// verify the signature hasn't already been added
-	if len(signed.Signatures) != 0 {
-		for _, v := range signed.Signatures {
-			if bytes.Equal(v.Signature, sig.Signature) {
-				return fmt.Errorf("already attached signature")
-			}
-		}
-	}
-	// verify that the signature signs the document
-	signed.Signatures = append(signed.Signatures, *sig)
-	_, _, _, err = signed.VerifyMulti(*publicKey.InternalPtr())
-	if err == nil {
-		// update object
-		d.raw = []byte(signed.FullSerialize())
-	}
-	return err
-}
-
 type state struct {
 	sync.RWMutex
 	worker.Worker
@@ -128,7 +94,7 @@ type state struct {
 	descriptors map[uint64]map[[eddsa.PublicKeySize]byte]*descriptor
 	votes       map[uint64]map[[eddsa.PublicKeySize]byte]*document
 	reveals     map[uint64]map[[eddsa.PublicKeySize]byte][]byte
-	signatures  map[uint64]map[[eddsa.PublicKeySize]byte]*jose.Signature
+	signatures  map[uint64]map[[eddsa.PublicKeySize]byte]*cert.Signature
 
 	updateCh       chan interface{}
 	bootstrapEpoch uint64
@@ -277,7 +243,8 @@ func (s *state) combine(epoch uint64) {
 	for pk, sig := range s.signatures[epoch] {
 		ed := new(eddsa.PublicKey)
 		ed.FromBytes(pk[:])
-		err := doc.addSig(ed, sig)
+		var err error
+		doc.raw, err = cert.AddSignature(ed, *sig, doc.raw)
 		if err != nil {
 			s.log.Errorf("Signature failed to validate: %v", err)
 		}
@@ -710,7 +677,7 @@ func (s *state) tallyVotes(epoch uint64) ([]*descriptor, *config.Parameters, err
 
 		ed := new(eddsa.PublicKey)
 		ed.FromBytes(pk[:])
-		vote, err := s11n.FromPayload(*ed.InternalPtr(), voteDoc.raw)
+		vote, err := s11n.FromPayload(ed, voteDoc.raw)
 		if err != nil {
 			s.log.Errorf("Skipping vote from Authority that failed to decode?! %v", err)
 			continue
@@ -759,9 +726,15 @@ func (s *state) tallyVotes(epoch uint64) ([]*descriptor, *config.Parameters, err
 	for rawDesc, votes := range mixTally {
 		if len(votes) > s.threshold {
 			// this shouldn't fail as the descriptors have already been verified
-			if desc, err := s11n.VerifyAndParseDescriptor([]byte(rawDesc), epoch); err == nil {
-				nodes = append(nodes, &descriptor{desc: desc, raw: []byte(rawDesc)})
+			verifier, err := s11n.GetVerifierFromDescriptor([]byte(rawDesc))
+			if err != nil {
+				return nil, nil, err
 			}
+			desc, err := s11n.VerifyAndParseDescriptor(verifier, []byte(rawDesc), epoch)
+			if err != nil {
+				return nil, nil, err
+			}
+			nodes = append(nodes, &descriptor{desc: desc, raw: []byte(rawDesc)})
 		} else if len(votes) >= s.dissenters {
 			return nil, nil, errors.New("Consensus failure!")
 		}
@@ -871,17 +844,7 @@ func (s *state) tabulate(epoch uint64) {
 	doc := s.getDocument(mixes, params, srv)
 
 	// Serialize and sign the Document.
-	// XXX s.signatures[epoch] might already be populated
-	// which means we might be voting with a multisig document.
-	// this isn't a problem because we extract the signature from
-	// the document and should be signing the same thing
-	signed, err := s11n.MultiSignDocument(s.s.identityKey, nil, doc)
-	if err != nil {
-		// This should basically always succeed.
-		s.log.Errorf("Failed to sign document: %v", err)
-		s.s.fatalErrCh <- err
-		return
-	}
+	signed, err := s11n.SignDocument(s.s.identityKey, doc)
 
 	// Ensure the document is sane.
 	pDoc, _, err := s11n.VerifyAndParseDocument([]byte(signed), s.s.identityKey.PublicKey())
@@ -1181,7 +1144,7 @@ func (s *state) onVoteUpload(vote *commands.Vote) commands.Command {
 	}
 	// haven't received a signature yet for this epoch
 	if _, ok := s.signatures[s.votingEpoch]; !ok {
-		s.signatures[s.votingEpoch] = make(map[[eddsa.PublicKeySize]byte]*jose.Signature)
+		s.signatures[s.votingEpoch] = make(map[[eddsa.PublicKeySize]byte]*cert.Signature)
 	}
 	// peer has not yet voted for this epoch
 	if !s.dupVote(*vote) {
@@ -1196,21 +1159,14 @@ func (s *state) onVoteUpload(vote *commands.Vote) commands.Command {
 		if !s.dupSig(*vote) {
 			// this was already verified by s11n.VerifyAndParseDocument(...)
 			// but we want to extract the signature from the payload
-			signed, err := jose.ParseSigned(string(vote.Payload))
+			sig, err := cert.GetSignature(vote.PublicKey.Identity(), vote.Payload)
 			if err != nil {
 				s.log.Errorf("onVoteUpload vote parse failure: %s", err)
 				resp.ErrorCode = commands.VoteNotSigned
 				return &resp
 			}
-			index, sig, _, err := signed.VerifyMulti(*vote.PublicKey.InternalPtr())
-			if err != nil || index != 0 {
-				s.log.Errorf("onVoteUpload signature parse failure: %s", err)
-				resp.ErrorCode = commands.VoteNotSigned
-				return &resp
-			}
-
 			s.log.Debugf("Signature OK.")
-			s.signatures[s.votingEpoch][vote.PublicKey.ByteArray()] = &sig
+			s.signatures[s.votingEpoch][vote.PublicKey.ByteArray()] = sig
 			resp.ErrorCode = commands.VoteOk
 			return &resp
 		}
@@ -1385,7 +1341,11 @@ func (s *state) restorePersistence() error {
 
 				c := eDescsBkt.Cursor()
 				for pk, rawDesc := c.First(); pk != nil; pk, rawDesc = c.Next() {
-					desc, err := s11n.VerifyAndParseDescriptor(rawDesc, epoch)
+					verifier, err := s11n.GetVerifierFromDescriptor([]byte(rawDesc))
+					if err != nil {
+						return err
+					}
+					desc, err := s11n.VerifyAndParseDescriptor(verifier, rawDesc, epoch)
 					if err != nil {
 						s.log.Errorf("Failed to validate persisted descriptor: %v", err)
 						continue
@@ -1456,7 +1416,7 @@ func newState(s *Server) (*state, error) {
 	st.documents = make(map[uint64]*document)
 	st.descriptors = make(map[uint64]map[[eddsa.PublicKeySize]byte]*descriptor)
 	st.votes = make(map[uint64]map[[eddsa.PublicKeySize]byte]*document)
-	st.signatures = make(map[uint64]map[[eddsa.PublicKeySize]byte]*jose.Signature)
+	st.signatures = make(map[uint64]map[[eddsa.PublicKeySize]byte]*cert.Signature)
 	st.reveals = make(map[uint64]map[[eddsa.PublicKeySize]byte][]byte)
 
 	// Initialize the persistence store and restore state.

--- a/voting/server/wire_handler.go
+++ b/voting/server/wire_handler.go
@@ -155,7 +155,12 @@ func (s *Server) onPostDescriptor(rAddr net.Addr, cmd *commands.PostDescriptor, 
 	}
 
 	// Validate and deserialize the descriptor.
-	desc, err := s11n.VerifyAndParseDescriptor(cmd.Payload, cmd.Epoch)
+	verifier, err := s11n.GetVerifierFromDescriptor(cmd.Payload)
+	if err != nil {
+		s.log.Errorf("Peer %v: Invalid descriptor: %v", rAddr, err)
+		return resp
+	}
+	desc, err := s11n.VerifyAndParseDescriptor(verifier, cmd.Payload, cmd.Epoch)
 	if err != nil {
 		s.log.Errorf("Peer %v: Invalid descriptor: %v", rAddr, err)
 		return resp


### PR DESCRIPTION

this PR eradicates jose from the voting authority. instead we use cert. this is very security critical.

we should audit very carefully. there is some slightly messy bits of code that really should be cleaned up before merging.

DO NOT MERGE IN HASTE.
HASTE MAKES WASTE.
SLOW IS SMOOTH.
SMOOTH IS FAST.
