### PR TITLE
Adds SharedRandomValue to document for compatibility.

### DIFF
--- a/nonvoting/server/state.go
+++ b/nonvoting/server/state.go
@@ -206,6 +206,9 @@ func (s *state) generateDocument(epoch uint64) {
 		Topology:          topology,
 		Providers:         providers,
 	}
+	// For compatibliity with shared s11n implementation between voting
+	// and non-voting authority, add SharedRandomValue.
+	doc.SharedRandomValue = make([]byte, s11n.SharedRandomValueLength)
 
 	// Serialize and sign the Document.
 	signed, err := s11n.SignDocument(s.s.identityKey, doc)


### PR DESCRIPTION
Nonvoting Authority implementation shares s11n.Document's
VerifyAndParseDocument, so this field is added for compatibility.