### PR TITLE
pki doc: correction to lambda params

### DIFF
--- a/internal/s11n/document.go
+++ b/internal/s11n/document.go
@@ -48,22 +48,19 @@ var (
 // Document is the on-the-wire representation of a PKI Document.
 type Document struct {
 	// Version uniquely identifies the document format as being for the
-        // specified version so that it can be rejected if the format changes.
+	// specified version so that it can be rejected if the format changes.
 	Version string
 
 	Epoch uint64
 
 	SendRatePerMinute uint64
 
-	MixLambda   float64
-	MixMaxDelay uint64
-
-	SendLambda      float64
-	SendMaxInterval uint64
-	DropLambda      float64
-	DropMaxInterval uint64
-	LoopLambda      float64
-	LoopMaxInterval uint64
+	MixLambda          float64
+	MixMaxDelay        uint64
+	SendLambda         float64
+	SendMaxInterval    uint64
+	MixLoopLambda      float64
+	MixLoopMaxInterval uint64
 
 	Topology  [][][]byte
 	Providers [][]byte
@@ -114,7 +111,7 @@ func MultiSignDocument(signer cert.Signer, peerSignatures []*cert.Signature, ver
 	}
 
 	// Sign the document.
-	expiration := time.Now().Add(3*epochtime.Period).Unix()
+	expiration := time.Now().Add(3 * epochtime.Period).Unix()
 	signed, err := cert.Sign(signer, payload, expiration)
 	if err != nil {
 		return nil, err
@@ -187,10 +184,8 @@ func VerifyAndParseDocument(b []byte, verifier cert.Verifier) (*pki.Document, er
 	doc.MixMaxDelay = d.MixMaxDelay
 	doc.SendLambda = d.SendLambda
 	doc.SendMaxInterval = d.SendMaxInterval
-	doc.DropLambda = d.DropLambda
-	doc.DropMaxInterval = d.DropMaxInterval
-	doc.LoopLambda = d.LoopLambda
-	doc.LoopMaxInterval = d.LoopMaxInterval
+	doc.MixLoopLambda = d.MixLoopLambda
+	doc.MixLoopMaxInterval = d.MixLoopMaxInterval
 	doc.Topology = make([][]*pki.MixDescriptor, len(d.Topology))
 	doc.Providers = make([]*pki.MixDescriptor, 0, len(d.Providers))
 

--- a/nonvoting/server/config/config.go
+++ b/nonvoting/server/config/config.go
@@ -39,21 +39,18 @@ const (
 	defaultMinNodesPerLayer = 2
 	absoluteMaxDelay        = 6 * 60 * 60 * 1000 // 6 hours.
 
-	// Note: These values are picked primarily for debugging and need to
-	// be changed to something more suitable for a production deployment
-	// at some point.
-	defaultMixLambda        = 0.00025
-	defaultMixMaxPercentile = 0.99999
-
 	// rate limiting of client connections
 	defaultSendRatePerMinute = 100
 
-	defaultSendLambda        = 0.00006
-	defaultSendMaxPercentile = 0.95
-	defaultDropLambda        = 0.00006
-	defaultDropMaxPercentile = 0.95
-	defaultLoopLambda        = 0.00006
-	defaultLoopMaxPercentile = 0.95
+	// Note: These values are picked primarily for debugging and need to
+	// be changed to something more suitable for a production deployment
+	// at some point.
+	defaultMixLambda            = 0.00025
+	defaultMixMaxPercentile     = 0.99999
+	defaultSendLambda           = 0.00006
+	defaultSendMaxPercentile    = 0.95
+	defaultMixLoopLambda        = 0.00006
+	defaultMixLoopMaxPercentile = 0.95
 )
 
 var defaultLogging = Logging{
@@ -141,19 +138,12 @@ type Parameters struct {
 	// SendMaxInterval is the maximum send interval in milliseconds.
 	SendMaxInterval uint64
 
-	// DropLambda is the inverse of the mean of the exponential distribution
-	// that clients will sample to determine send timing of drop decoy messages.
-	DropLambda float64
-
-	// DropMaxInterval is the maximum send interval in milliseconds.
-	DropMaxInterval uint64
-
-	// LoopLambda is the inverse of the mean of the exponential distribution
+	// MixLoopLambda is the inverse of the mean of the exponential distribution
 	// that clients will sample to determine send timing of loop decoy messages.
-	LoopLambda float64
+	MixLoopLambda float64
 
-	// LoopMaxInterval is the maximum send interval in milliseconds.
-	LoopMaxInterval uint64
+	// MixLoopMaxInterval is the maximum send interval in milliseconds.
+	MixLoopMaxInterval uint64
 }
 
 func (pCfg *Parameters) validate() error {
@@ -188,17 +178,11 @@ func (pCfg *Parameters) applyDefaults() {
 	if pCfg.SendMaxInterval == 0 {
 		pCfg.SendMaxInterval = uint64(rand.ExpQuantile(pCfg.SendLambda, defaultSendMaxPercentile))
 	}
-	if pCfg.DropLambda == 0 {
-		pCfg.DropLambda = defaultDropLambda
+	if pCfg.MixLoopLambda == 0 {
+		pCfg.MixLoopLambda = defaultMixLoopLambda
 	}
-	if pCfg.DropMaxInterval == 0 {
-		pCfg.DropMaxInterval = uint64(rand.ExpQuantile(pCfg.DropLambda, defaultDropMaxPercentile))
-	}
-	if pCfg.LoopLambda == 0 {
-		pCfg.LoopLambda = defaultLoopLambda
-	}
-	if pCfg.LoopMaxInterval == 0 {
-		pCfg.LoopMaxInterval = uint64(rand.ExpQuantile(pCfg.LoopLambda, defaultLoopMaxPercentile))
+	if pCfg.MixLoopMaxInterval == 0 {
+		pCfg.MixLoopMaxInterval = uint64(rand.ExpQuantile(pCfg.MixLoopLambda, defaultMixLoopMaxPercentile))
 	}
 }
 

--- a/nonvoting/server/state.go
+++ b/nonvoting/server/state.go
@@ -193,18 +193,16 @@ func (s *state) generateDocument(epoch uint64) {
 
 	// Build the Document.
 	doc := &s11n.Document{
-		Epoch:             epoch,
-		SendRatePerMinute: s.s.cfg.Parameters.SendRatePerMinute,
-		MixLambda:         s.s.cfg.Parameters.MixLambda,
-		MixMaxDelay:       s.s.cfg.Parameters.MixMaxDelay,
-		SendLambda:        s.s.cfg.Parameters.SendLambda,
-		SendMaxInterval:   s.s.cfg.Parameters.SendMaxInterval,
-		DropLambda:        s.s.cfg.Parameters.DropLambda,
-		DropMaxInterval:   s.s.cfg.Parameters.DropMaxInterval,
-		LoopLambda:        s.s.cfg.Parameters.LoopLambda,
-		LoopMaxInterval:   s.s.cfg.Parameters.LoopMaxInterval,
-		Topology:          topology,
-		Providers:         providers,
+		Epoch:              epoch,
+		SendRatePerMinute:  s.s.cfg.Parameters.SendRatePerMinute,
+		MixLambda:          s.s.cfg.Parameters.MixLambda,
+		MixMaxDelay:        s.s.cfg.Parameters.MixMaxDelay,
+		SendLambda:         s.s.cfg.Parameters.SendLambda,
+		SendMaxInterval:    s.s.cfg.Parameters.SendMaxInterval,
+		MixLoopLambda:      s.s.cfg.Parameters.MixLoopLambda,
+		MixLoopMaxInterval: s.s.cfg.Parameters.MixLoopMaxInterval,
+		Topology:           topology,
+		Providers:          providers,
 	}
 	// For compatibliity with shared s11n implementation between voting
 	// and non-voting authority, add SharedRandomValue.

--- a/voting/server/state.go
+++ b/voting/server/state.go
@@ -294,18 +294,16 @@ func (s *state) getDocument(descriptors []*descriptor, params *config.Parameters
 
 	// Build the Document.
 	doc := &s11n.Document{
-		Epoch:             s.votingEpoch,
-		MixLambda:         params.MixLambda,
-		MixMaxDelay:       params.MixMaxDelay,
-		SendLambda:        params.SendLambda,
-		SendMaxInterval:   params.SendMaxInterval,
-		DropLambda:        params.DropLambda,
-		DropMaxInterval:   params.DropMaxInterval,
-		LoopLambda:        params.LoopLambda,
-		LoopMaxInterval:   params.LoopMaxInterval,
-		Topology:          topology,
-		Providers:         providers,
-		SharedRandomValue: srv,
+		Epoch:              s.votingEpoch,
+		MixLambda:          params.MixLambda,
+		MixMaxDelay:        params.MixMaxDelay,
+		SendLambda:         params.SendLambda,
+		SendMaxInterval:    params.SendMaxInterval,
+		MixLoopLambda:      params.MixLoopLambda,
+		MixLoopMaxInterval: params.MixLoopMaxInterval,
+		Topology:           topology,
+		Providers:          providers,
+		SharedRandomValue:  srv,
 	}
 	return doc
 }
@@ -671,14 +669,12 @@ func (s *state) tallyVotes(epoch uint64) ([]*descriptor, *config.Parameters, err
 		}
 		// serialize the vote parameters and tally these as well.
 		params := &config.Parameters{
-			MixLambda:       vote.MixLambda,
-			MixMaxDelay:     vote.MixMaxDelay,
-			SendLambda:      vote.SendLambda,
-			SendMaxInterval: vote.SendMaxInterval,
-			DropLambda:      vote.DropLambda,
-			DropMaxInterval: vote.DropMaxInterval,
-			LoopLambda:      vote.LoopLambda,
-			LoopMaxInterval: vote.LoopMaxInterval,
+			MixLambda:          vote.MixLambda,
+			MixMaxDelay:        vote.MixMaxDelay,
+			SendLambda:         vote.SendLambda,
+			SendMaxInterval:    vote.SendMaxInterval,
+			MixLoopLambda:      vote.MixLoopLambda,
+			MixLoopMaxInterval: vote.MixLoopMaxInterval,
 		}
 		b := bytes.Buffer{}
 		e := gob.NewEncoder(&b)


### PR DESCRIPTION
allow for separately tuning the mix loop decoy traffic and only give
the client two lambda params: send interval and per hop delay. Removal
of drop decoy lambda.