### PR TITLE
Fix consensus fetch

### DIFF
--- a/voting/server/state.go
+++ b/voting/server/state.go
@@ -476,9 +476,16 @@ func (s *state) hasEnoughDescriptors(m map[[eddsa.PublicKeySize]byte]*descriptor
 }
 
 func (s *state) sendRevealToPeer(peer *config.AuthorityPeer, reveal []byte, epoch uint64) error {
-	conn, err := net.Dial("tcp", peer.Addresses[0]) // XXX
-	if err != nil {
-		return err
+	var conn net.Conn
+	var err error
+	for i, a := range peer.Addresses {
+		conn, err = net.Dial("tcp", a)
+		if err == nil {
+			break
+		}
+		if i == len(peer.Addresses) - 1 {
+			return err
+		}
 	}
 	defer conn.Close()
 	s.s.Add(1)
@@ -534,9 +541,16 @@ func (s *state) sendRevealToPeer(peer *config.AuthorityPeer, reveal []byte, epoc
 }
 func (s *state) sendVoteToPeer(peer *config.AuthorityPeer, vote []byte, epoch uint64) error {
 	// get a connector here
-	conn, err := net.Dial("tcp", peer.Addresses[0]) // XXX
-	if err != nil {
-		return err
+	var conn net.Conn
+	var err error
+	for i, a := range peer.Addresses {
+		conn, err = net.Dial("tcp", a)
+		if err == nil {
+			break
+		}
+		if i == len(peer.Addresses) - 1 {
+			return err
+		}
 	}
 	defer conn.Close()
 	s.s.Add(1)

--- a/voting/server/state.go
+++ b/voting/server/state.go
@@ -149,14 +149,15 @@ func (s *state) fsm() <-chan time.Time {
 		s.backgroundFetchConsensus(epoch)
 		if elapsed > mixPublishDeadline {
 			s.log.Debugf("Too late to vote this round, sleeping until %s", nextEpoch)
-			sleep = nextEpoch + mixPublishDeadline
+			sleep = nextEpoch
 			s.votingEpoch = epoch + 2
+			s.state = stateBootstrap
 		} else {
 			s.votingEpoch = epoch + 1
 			sleep = mixPublishDeadline - elapsed
+			s.state = stateAcceptDescriptor
 		}
 		s.log.Debugf("Bootstrapping for %d", s.votingEpoch)
-		s.state = stateAcceptDescriptor
 	case stateAcceptDescriptor:
 		if !s.hasEnoughDescriptors(s.descriptors[s.votingEpoch]) {
 			s.log.Debugf("Not voting because insufficient descriptors uploaded for epoch %d!", s.votingEpoch)

--- a/voting/server/state.go
+++ b/voting/server/state.go
@@ -1218,13 +1218,6 @@ func (s *state) documentForEpoch(epoch uint64) ([]byte, error) {
 	now, _, till := epochtime.Now()
 	switch epoch {
 	case now:
-		// Check to see if we are doing a bootstrap, and it's possible that
-		// we may decide to publish a document at some point ignoring the
-		// standard schedule.
-		if now == s.votingEpoch {
-			return nil, errNotYet
-		}
-
 		// We missed the deadline to publish a descriptor for the current
 		// epoch, so we will never be able to service this request.
 		return nil, errGone


### PR DESCRIPTION
fixes a bug where an authority fails to fetch a prior consensus before generating the topology for that voting round.