### PR TITLE
Remove GetConsensus() method

### DIFF
--- a/voting/server/state.go
+++ b/voting/server/state.go
@@ -755,15 +755,6 @@ func (s *state) tallyVotes(epoch uint64) ([]*descriptor, *config.Parameters, err
 	return nil, nil, errors.New("consensus failure")
 }
 
-func (s *state) GetConsensus(epoch uint64) (*document, error) {
-	s.Lock()
-	defer s.Unlock()
-	if d := s.documents[epoch]; d != nil {
-		return d, nil
-	}
-	return nil, errNotYet
-}
-
 func (s *state) isTabulated(epoch uint64) bool {
 	if _, ok := s.documents[epoch]; ok {
 		return true

--- a/voting/server/state.go
+++ b/voting/server/state.go
@@ -1210,7 +1210,7 @@ func (s *state) onDescriptorUpload(rawDesc []byte, desc *pki.MixDescriptor, epoc
 }
 
 func (s *state) documentForEpoch(epoch uint64) ([]byte, error) {
-	var generationDeadline = 7 * (epochtime.Period / 8)
+	var generationDeadline = (epochtime.Period / 8)
 
 	s.RLock()
 	defer s.RUnlock()

--- a/voting/server/wire_handler.go
+++ b/voting/server/wire_handler.go
@@ -154,7 +154,7 @@ func (s *Server) onReveal(cmd *commands.Reveal) commands.Command {
 
 func (s *Server) onGetConsensus(rAddr net.Addr, cmd *commands.GetConsensus) commands.Command {
 	resp := &commands.Consensus{}
-	doc, err := s.state.GetConsensus(cmd.Epoch)
+	doc, err := s.state.documentForEpoch(cmd.Epoch)
 	if err != nil {
 		s.log.Errorf("Peer %v: Failed to retreive document for epoch '%v': %v", rAddr, cmd.Epoch, err)
 		switch err {
@@ -166,7 +166,7 @@ func (s *Server) onGetConsensus(rAddr net.Addr, cmd *commands.GetConsensus) comm
 	} else {
 		s.log.Debugf("Peer: %v: Serving document for epoch %v.", rAddr, cmd.Epoch)
 		resp.ErrorCode = commands.ConsensusOk
-		resp.Payload = doc.raw
+		resp.Payload = doc
 	}
 	return resp
 }


### PR DESCRIPTION
method documentForEpoch is more correct, as it returns ErrGone as specified.